### PR TITLE
Use of Mitre techniques, add docstrings

### DIFF
--- a/pydragonfly/cli/resources/_renderables.py
+++ b/pydragonfly/cli/resources/_renderables.py
@@ -54,8 +54,13 @@ def _display_single_analysis(data: Dict) -> None:
                 f"{style}Status:[/] {get_status_text(data['status'], False)}",
                 f"{style}Evaluation:[/] {get_status_text(data['evaluation'], False)}",
                 f"{style}Weight:[/] {data['weight']}",
-                f"{style}Malware Families:[/] {data['malware_families']}",
-                f"{style}Mitre Techniques:[/] {data['mitre_techniques']}",
+                f"{style}Malware Families:[/] " + ",".join(data["malware_families"]),
+                f"{style}Mitre Techniques:[/] "
+                + ",".join(
+                    f"[link={technique['mitre_url']}]{technique['name']}[/link]"
+                    for tactic in data["mitre_techniques"]
+                    for technique in tactic["techniques"]
+                ),
             ),
             title="Result Overview",
         ),
@@ -100,7 +105,10 @@ def _generate_analysis_table(rows: List[Dict]) -> Table:
             f"[link={el['gui_url']}]{Emoji('link')} {el['id']}[/link]",
             get_datetime_text(el["created_at"]),
             f"{el['sample']['filename']}\n({el['sample']['os']}, {el['sample']['arch']}, {el['sample']['mode']})",
-            ",".join(el["mitre_techniques"]),
+            ",".join(
+                f"[link={tactic['mitre_url']}]{tactic['name']}[/link]"
+                for tactic in el["mitre_techniques"]
+            ),
             ",".join(el["malware_families"]),
             get_status_text(el["status"]),
             get_status_text(el["evaluation"]),
@@ -147,10 +155,12 @@ def _generate_rule_table(rows: List[Dict]) -> Table:
             str(el["id"]),
             get_success_text(str(el["enabled"])),
             el["rule"],
-            get_json_syntax(el["meta_description"]),
-            el["mitre_technique"],
+            get_json_syntax(el["meta_description"]) if el["meta_description"] else None,
+            f"[link={el['mitre_technique']['mitre_url']}]{el['mitre_technique']['name']}[/link]"
+            if el["mitre_technique"]
+            else None,
             el["malware_family"],
-            get_json_syntax(el["variables"]),
+            get_json_syntax(el["variables"]) if el["variables"] else None,
             get_weight_text(el["weight"]),
         )
     return table

--- a/pydragonfly/cli/resources/_renderables.py
+++ b/pydragonfly/cli/resources/_renderables.py
@@ -1,17 +1,18 @@
 # flake8: noqa: E501
-from typing import List, Dict
+from typing import Dict, List
+
 from rich import box
+from rich.console import Console, RenderGroup
 from rich.emoji import Emoji
 from rich.panel import Panel
 from rich.table import Table
-from rich.console import RenderGroup, Console
 
 from .._utils import (
+    get_datetime_text,
+    get_json_syntax,
     get_status_text,
     get_success_text,
     get_weight_text,
-    get_datetime_text,
-    get_json_syntax,
 )
 
 
@@ -54,7 +55,7 @@ def _display_single_analysis(data: Dict) -> None:
                 f"{style}Evaluation:[/] {get_status_text(data['evaluation'], False)}",
                 f"{style}Weight:[/] {data['weight']}",
                 f"{style}Malware Families:[/] {data['malware_families']}",
-                f"{style}Malware Behaviours:[/] {data['malware_behaviours']}",
+                f"{style}Mitre Techniques:[/] {data['mitre_techniques']}",
             ),
             title="Result Overview",
         ),
@@ -87,7 +88,7 @@ def _generate_analysis_table(rows: List[Dict]) -> Table:
         "ID",
         "Created",
         "Sample",
-        "alware\nBehaviours",
+        "Mitre\nTechniques",
         "Malware\nFamilies",
         "Status",
         "Evaluation",
@@ -99,7 +100,7 @@ def _generate_analysis_table(rows: List[Dict]) -> Table:
             f"[link={el['gui_url']}]{Emoji('link')} {el['id']}[/link]",
             get_datetime_text(el["created_at"]),
             f"{el['sample']['filename']}\n({el['sample']['os']}, {el['sample']['arch']}, {el['sample']['mode']})",
-            ",".join(el["malware_behaviours"]),
+            ",".join(el["mitre_techniques"]),
             ",".join(el["malware_families"]),
             get_status_text(el["status"]),
             get_status_text(el["evaluation"]),
@@ -135,7 +136,7 @@ def _generate_rule_table(rows: List[Dict]) -> Table:
         "Enabled",
         "Name",
         "Meta",
-        "Malware\nBehaviour",
+        "Mitre\nTechnique",
         "Malware\nFamily",
         "Variables",
         "Weight",
@@ -147,7 +148,7 @@ def _generate_rule_table(rows: List[Dict]) -> Table:
             get_success_text(str(el["enabled"])),
             el["rule"],
             get_json_syntax(el["meta_description"]),
-            el["malware_behaviour"],
+            el["mitre_technique"],
             el["malware_family"],
             get_json_syntax(el["variables"]),
             get_weight_text(el["weight"]),

--- a/pydragonfly/sdk/dragonfly.py
+++ b/pydragonfly/sdk/dragonfly.py
@@ -94,6 +94,8 @@ class Dragonfly(APIClient):
             ``dll_entrypoints`` (List[str], optional):
              DLL entrypoints.
              Default ``None``.
+
+        .. versionadded:: 0.0.4
         """
         if profiles is None:
             profiles = [1, 2]
@@ -142,6 +144,8 @@ class Dragonfly(APIClient):
             Wait time between subsequent HTTP requests. Default ``10``.\n
            ``max_wait_cycle`` (int, optional):
             Maximum number of HTTP requests. Default ``30``.
+
+        .. versionadded:: 0.0.4
         """
         result = self.Analysis.Result(analysis_id)
         if max_wait_cycle:

--- a/pydragonfly/sdk/resources/analysis.py
+++ b/pydragonfly/sdk/resources/analysis.py
@@ -39,7 +39,7 @@ class AnalysisResult:
     weight: int = 0
     malware_families: List[str] = []
     malware_behaviours: List[str] = []  # deprecated
-    mitre_techniques: List[str] = []
+    mitre_techniques: List[Dict] = []
     sample: Dict = {}
     reports: List[Dict] = []
     matched_rules: List[RuleResult] = []
@@ -116,7 +116,12 @@ class AnalysisResult:
         self.evaluation = data["evaluation"]
         self.weight = data["weight"]
         self.malware_families = data["malware_families"]
-        self.malware_behaviours = self.mitre_techniques = data["mitre_techniques"]
+        self.mitre_techniques = data["mitre_techniques"]
+        self.malware_behaviours = [  # deprecated
+            technique["name"]
+            for tactic in self.mitre_techniques
+            for technique in tactic["techniques"]
+        ]
         self.sample = data["sample"]
         self.reports = data["reports"]
         matched_rules: Set[AnalysisResult.RuleResult] = set()
@@ -138,7 +143,7 @@ class AnalysisResult:
         self.malware_family = (
             self.malware_families[0] if self.malware_families else None
         )
-        self.malware_behaviour = (
+        self.malware_behaviour = (  # deprecated
             self.malware_behaviours[0] if self.malware_behaviours else None
         )
         self.errors = list(

--- a/pydragonfly/sdk/resources/analysis.py
+++ b/pydragonfly/sdk/resources/analysis.py
@@ -18,6 +18,10 @@ from .report import Report
 
 
 class AnalysisResult:
+    """
+    .. versionadded:: 0.0.4
+    """
+
     @dataclasses.dataclass
     class RuleResult:
         name: str
@@ -38,7 +42,9 @@ class AnalysisResult:
     evaluation: str = CLEAN
     weight: int = 0
     malware_families: List[str] = []
-    malware_behaviours: List[str] = []  # deprecated
+    #: deprecated in favor of ``mitre_techniques``.
+    malware_behaviours: List[str] = []
+    #: .. versionadded:: 0.1.0
     mitre_techniques: List[Dict] = []
     sample: Dict = {}
     reports: List[Dict] = []
@@ -46,7 +52,8 @@ class AnalysisResult:
     # extras
     score: int = 0
     malware_family: Optional[str] = None
-    malware_behaviour: Optional[str] = None  # deprecated
+    #: deprecated
+    malware_behaviour: Optional[str] = None
     errors: List[str] = []
 
     def __init__(self, analysis_id: Toid):

--- a/pydragonfly/sdk/resources/analysis.py
+++ b/pydragonfly/sdk/resources/analysis.py
@@ -1,6 +1,5 @@
 import dataclasses
-from typing import List, Optional, Set
-from typing_extensions import Literal
+from typing import Dict, List, Optional, Set
 
 from django_rest_client import (
     APIResource,
@@ -11,8 +10,10 @@ from django_rest_client import (
     RetrievableAPIResourceMixin,
 )
 from django_rest_client.types import Toid, TParams
+from typing_extensions import Literal
 
 from pydragonfly.sdk.const import ANALYZED, CLEAN, FAILED, REVOKED
+
 from .report import Report
 
 
@@ -36,16 +37,16 @@ class AnalysisResult:
     status: str
     evaluation: str = CLEAN
     weight: int = 0
-    malware_family: Optional[str] = None
     malware_families: List[str] = []
-    malware_behaviours: List[str] = []
-    sample: dict = {}
-    reports: List[dict] = []
+    malware_behaviours: List[str] = []  # deprecated
+    mitre_techniques: List[str] = []
+    sample: Dict = {}
+    reports: List[Dict] = []
     matched_rules: List[RuleResult] = []
     # extras
     score: int = 0
     malware_family: Optional[str] = None
-    malware_behaviour: Optional[str] = None
+    malware_behaviour: Optional[str] = None  # deprecated
     errors: List[str] = []
 
     def __init__(self, analysis_id: Toid):
@@ -63,7 +64,7 @@ class AnalysisResult:
             "weight": self.weight,
             "score": self.score,
             "malware_families": self.malware_families,
-            "malware_behaviours": self.malware_behaviours,
+            "mitre_techniques": self.mitre_techniques,
             "sample": self.sample,
             "reports": self.reports,
             "matched_rules": [dataclasses.asdict(mr) for mr in self.matched_rules],
@@ -115,7 +116,7 @@ class AnalysisResult:
         self.evaluation = data["evaluation"]
         self.weight = data["weight"]
         self.malware_families = data["malware_families"]
-        self.malware_behaviours = data["malware_behaviours"]
+        self.malware_behaviours = self.mitre_techniques = data["mitre_techniques"]
         self.sample = data["sample"]
         self.reports = data["reports"]
         matched_rules: Set[AnalysisResult.RuleResult] = set()

--- a/pydragonfly/sdk/resources/rule.py
+++ b/pydragonfly/sdk/resources/rule.py
@@ -1,14 +1,14 @@
 import dataclasses
-from typing import Optional, List
-from typing_extensions import Literal
+from typing import List, Optional
+
 from django_rest_client import (
     APIResource,
     APIResponse,
-    RetrievableAPIResourceMixin,
-    ListableAPIResourceMixin,
     CreateableAPIResourceMixin,
-    UpdateableAPIResourceMixin,
+    ListableAPIResourceMixin,
     PaginationAPIResourceMixin,
+    RetrievableAPIResourceMixin,
+    UpdateableAPIResourceMixin,
 )
 from django_rest_client.types import Toid, TParams
 
@@ -20,25 +20,7 @@ class CreateRuleRequestBody:
     modules: dict
     variables: List[str] = dataclasses.field(default_factory=list)
     malware_family: str = ""
-    malware_behaviour: Literal[
-        "PUA",
-        "Riskware",
-        "Adware",
-        "Greyware",
-        "Downloader",
-        "Bot",
-        "Trojan",
-        "Backdoor",
-        "Coinminer",
-        "Worm",
-        "Rootkit",
-        "Infostealer",
-        "Banker",
-        "Ransomware",
-        "Spyware",
-        "Miner",
-        "Unpacker",
-    ] = ""
+    mitre_technique: str = None
     meta_description: dict = dataclasses.field(default_factory=dict)
     sensitive: bool = False
 
@@ -70,7 +52,7 @@ class Rule(
         "rule",
         "weight",
         "malware_family",
-        "malware_behaviour",
+        "mitre_technique",
     ]
 
     # models
@@ -99,9 +81,22 @@ class Rule(
         return super().update(object_id=object_id, data=post_data, params=params)
 
     @classmethod
+    def mitre(cls, params: Optional[TParams] = None) -> APIResponse:
+        url = cls.class_url() + "/mitre"
+        return cls._request("GET", url=url, params=params)
+
+    @classmethod
     def aggregate_malware_behaviour(
         cls,
         params: Optional[TParams] = None,
     ) -> APIResponse:
-        url = cls.class_url() + "/aggregate/malware_behaviour"
+        # deprecated
+        return cls.aggregate_mitre_technique(params=params)
+
+    @classmethod
+    def aggregate_mitre_technique(
+        cls,
+        params: Optional[TParams] = None,
+    ) -> APIResponse:
+        url = cls.class_url() + "/aggregate/mitre_technique"
         return cls._request("GET", url=url, params=params)

--- a/pydragonfly/sdk/resources/rule.py
+++ b/pydragonfly/sdk/resources/rule.py
@@ -82,6 +82,9 @@ class Rule(
 
     @classmethod
     def mitre(cls, params: Optional[TParams] = None) -> APIResponse:
+        """
+        .. versionadded:: 0.1.0
+        """
         url = cls.class_url() + "/mitre"
         return cls._request("GET", url=url, params=params)
 
@@ -90,7 +93,10 @@ class Rule(
         cls,
         params: Optional[TParams] = None,
     ) -> APIResponse:
-        # deprecated
+        """
+        Deprecated in favor of ``aggregate_mitre_technique``.
+        Will be removed in next release.
+        """
         return cls.aggregate_mitre_technique(params=params)
 
     @classmethod
@@ -98,5 +104,19 @@ class Rule(
         cls,
         params: Optional[TParams] = None,
     ) -> APIResponse:
+        """
+        .. versionadded:: 0.1.0
+        """
         url = cls.class_url() + "/aggregate/mitre_technique"
+        return cls._request("GET", url=url, params=params)
+
+    @classmethod
+    def aggregate_behaviour(
+        cls,
+        params: Optional[TParams] = None,
+    ) -> APIResponse:
+        """
+        .. versionadded:: 0.1.0
+        """
+        url = cls.class_url() + "/aggregate/behaviour"
         return cls._request("GET", url=url, params=params)

--- a/pydragonfly/sdk/resources/user_preferences.py
+++ b/pydragonfly/sdk/resources/user_preferences.py
@@ -21,6 +21,8 @@ class UserPreferences(
 ):
     """
     :class:`pydragonfly.Dragonfly.UserPreferences`
+
+    .. versionadded:: 0.0.2
     """
 
     OBJECT_NAME = "api.me.preferences"

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -29,7 +29,7 @@ class AnalysisResultTestCase(TestCase):
         "evaluation": "MALICIOUS",
         "weight": 120,
         "malware_families": ["Ransomware", "Trojan"],
-        "malware_behaviours": ["Crypt", "Test"],
+        "mitre_techniques": ["Crypt", "Test"],
         "sample": {"id": 1, "filename": "test"},
         "reports": [
             {

--- a/tests/resources/test_analysis.py
+++ b/tests/resources/test_analysis.py
@@ -29,7 +29,20 @@ class AnalysisResultTestCase(TestCase):
         "evaluation": "MALICIOUS",
         "weight": 120,
         "malware_families": ["Ransomware", "Trojan"],
-        "mitre_techniques": ["Crypt", "Test"],
+        "mitre_techniques": [
+            {
+                "tid": "tactic_tid",
+                "name": "test_tactic",
+                "description": "test",
+                "techniques": [
+                    {
+                        "tid": "technique_tid",
+                        "name": "test_technique",
+                        "description": "test",
+                    }
+                ],
+            }
+        ],
         "sample": {"id": 1, "filename": "test"},
         "reports": [
             {
@@ -59,7 +72,25 @@ class AnalysisResultTestCase(TestCase):
         self.assertEqual(result.reports, self.result_json["reports"])
         self.assertEqual(result.score, 10)
         self.assertEqual(result.malware_family, "Ransomware")
-        self.assertEqual(result.malware_behaviour, "Crypt")
+        self.assertEqual(result.malware_behaviour, "test_technique")
+        self.assertEqual(result.malware_behaviours, ["test_technique"])
+        self.assertEqual(
+            result.mitre_techniques,
+            [
+                {
+                    "tid": "tactic_tid",
+                    "name": "test_tactic",
+                    "description": "test",
+                    "techniques": [
+                        {
+                            "tid": "technique_tid",
+                            "name": "test_technique",
+                            "description": "test",
+                        }
+                    ],
+                }
+            ],
+        )
         self.assertEqual(result.errors, ["Internal error"])
         self.assertEqual(len(result.matched_rules), 1)
         self.assertEqual(result.matched_rules[0].name, "TestRule")

--- a/tests/resources/test_rule.py
+++ b/tests/resources/test_rule.py
@@ -1,6 +1,6 @@
-from . import APIResourceBaseTestCase, APIResource
-
 from tests.mock_utils import generic_200_mock, generic_201_mock
+
+from . import APIResource, APIResourceBaseTestCase
 
 
 class RuleResourceTestCase(APIResourceBaseTestCase):
@@ -20,7 +20,7 @@ class RuleResourceTestCase(APIResourceBaseTestCase):
                     "order": True,
                 },
                 malware_family="test__create",
-                malware_behaviour="PUA",
+                mitre_technique="T1548",
                 sensitive=False,
                 meta_description={"author": "test__create"},
             )
@@ -38,4 +38,14 @@ class RuleResourceTestCase(APIResourceBaseTestCase):
     @generic_200_mock
     def test__aggregate_malware_behaviour(self, *args, **kwargs):
         response = self.resource.aggregate_malware_behaviour()
+        self.assertEqual(200, response.code)
+
+    @generic_200_mock
+    def test__aggregate_mitre_technique(self, *args, **kwargs):
+        response = self.resource.aggregate_mitre_technique()
+        self.assertEqual(200, response.code)
+
+    @generic_200_mock
+    def test__mitre(self, *args, **kwargs):
+        response = self.resource.mitre()
         self.assertEqual(200, response.code)

--- a/tests/resources/test_rule.py
+++ b/tests/resources/test_rule.py
@@ -36,6 +36,11 @@ class RuleResourceTestCase(APIResourceBaseTestCase):
         self.assertEqual(200, response.code)
 
     @generic_200_mock
+    def test__mitre(self, *args, **kwargs):
+        response = self.resource.mitre()
+        self.assertEqual(200, response.code)
+
+    @generic_200_mock
     def test__aggregate_malware_behaviour(self, *args, **kwargs):
         response = self.resource.aggregate_malware_behaviour()
         self.assertEqual(200, response.code)
@@ -46,6 +51,6 @@ class RuleResourceTestCase(APIResourceBaseTestCase):
         self.assertEqual(200, response.code)
 
     @generic_200_mock
-    def test__mitre(self, *args, **kwargs):
-        response = self.resource.mitre()
+    def test__aggregate_behaviour(self, *args, **kwargs):
+        response = self.resource.aggregate_behaviour()
         self.assertEqual(200, response.code)


### PR DESCRIPTION
# Description

Added mitre techniques endpoint + modified rule creation


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

The `malware behaviours`  endpoint in the `analysis` resource is still present, but is now deprecated. In the next major release they will be removed. They are currently pointing to the mitre endpoints.

The `malware_behaviour` parameter in the `rule creation` endpoint has been replace with `mitre_technique`. The TID of the technique should be providided.
